### PR TITLE
コメントアウト

### DIFF
--- a/app/views/users/registrations/basic.html.haml
+++ b/app/views/users/registrations/basic.html.haml
@@ -65,7 +65,7 @@
             %p ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .input-content__form
             .form-confirm-recaptcha
-              = recaptcha_tags
+              -# = recaptcha_tags
           .input-content__form
             .input-content__form--terms
               「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします


### PR DESCRIPTION
# WHAT
recaoptchaタグを一旦コメントアウト

# WHY
本番環境にデプロイした際に、エラー(No Site Key)が起き、
他の作業に取り組めないため。
※現在吉田が対応中です。